### PR TITLE
Make mktemp arguments compatible with OS X.

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -11,7 +11,7 @@
 exec 1>&2
 
 PUPPETLINT_FLAGS=${PUPPETLINT_FLAGS:-"--no-autoloader_layout-check --no-80chars-check"}
-TMPFILE=$(mktemp)
+TMPFILE=$(mktemp /tmp/tmp.XXXXXXXXXX)
 STATUS=0
 
 # Register exit trap for removing temporary files


### PR DESCRIPTION
OS X has slightly different mktemp syntax from Linux; I believe the attached pull request should fix the pre-commit hook to work on both OS X and Linux (I tested against Ubuntu 12.04 and OS X 10.8.2).

Thanks,
Andy
