### PR TITLE
Fix puppet lint output format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ before_script:
   - 'bundle install'
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
+  - 2.1.9
 env:
-  - PUPPET_VERSION=2.7.23
-  - PUPPET_VERSION=3.0.2
-  - PUPPET_VERSION=3.1.1
-  - PUPPET_VERSION=3.2.4
+  - PUPPET_VERSION=3.8.5
+  - PUPPET_VERSION=4.10.5

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -78,7 +78,7 @@ do
                 fi
 
                 # puppet-lint check
-                puppet-lint $PUPPETLINT_FLAGS --log-format "${file}:%{linenumber} %{KIND} - %{message}" $TMPFILE 2> /dev/null
+                puppet-lint $PUPPETLINT_FLAGS --log-format "${file}:%{line} %{KIND} - %{message}" $TMPFILE 
                 if [[ $? -ne 0 ]] ; then
                     STATUS=2
                 fi


### PR DESCRIPTION
- Uses the newer style output format for puppet-lint, witch is failing
for more recent puppet versions otherwise
- Removes STDERR pipe to `/dev/null` to make errors more
transparent.