### PR TITLE
Fix puppet-lint formatting to use line instead of linenumber

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -78,7 +78,7 @@ do
                 fi
 
                 # puppet-lint check
-                puppet-lint $PUPPETLINT_FLAGS --log-format "${file}:%{linenumber} %{KIND} - %{message}" $TMPFILE 2> /dev/null
+                puppet-lint $PUPPETLINT_FLAGS --log-format "${file}:%{line} %{KIND} - %{message}" $TMPFILE 2> /dev/null
                 if [[ $? -ne 0 ]] ; then
                     STATUS=2
                 fi


### PR DESCRIPTION
It's use has apparently been deprecated for a while and was finally removed in August 2016: https://github.com/rodjek/puppet-lint/issues/539